### PR TITLE
✨ Feat : 술 이름 가려지면 상단바 생성 및 코드 리팩토링(설명)

### DIFF
--- a/src/app/drink/_components/DrinkBasicInfo.tsx
+++ b/src/app/drink/_components/DrinkBasicInfo.tsx
@@ -1,5 +1,7 @@
 import { Database } from '@/types/supabase';
 
+import DrinkInfoRow from './DrinkInfoRow';
+
 type Drink = Database['public']['Tables']['drinks']['Row'];
 
 const DrinkBasicInfo = ({ drink }: { drink: Drink }) => (
@@ -10,24 +12,10 @@ const DrinkBasicInfo = ({ drink }: { drink: Drink }) => (
         {drink.ingredients || '재료 정보 없음'}
       </p>
       <div className="mt-2 space-y-2 text-sm">
-        <div className="flex justify-between">
-          <p className="font-semibold">주종</p>
-          <p className="text-gray-700">{drink.type || '정보 없음'}</p>
-        </div>
-        <div className="flex justify-between">
-          <p className="font-semibold">도수</p>
-          <p className="text-gray-700">
-            {drink.alcohol_content || '정보 없음'}
-          </p>
-        </div>
-        <div className="flex justify-between">
-          <p className="font-semibold">용량</p>
-          <p className="text-gray-700">{drink.volume || '정보 없음'}</p>
-        </div>
-        <div className="flex justify-between">
-          <p className="font-semibold">제조사</p>
-          <p className="text-gray-700">{drink.manufacturer || '정보 없음'}</p>
-        </div>
+        <DrinkInfoRow label="주종" value={drink.type} />
+        <DrinkInfoRow label="도수" value={drink.alcohol_content} />
+        <DrinkInfoRow label="용량" value={drink.volume} />
+        <DrinkInfoRow label="제조사" value={drink.manufacturer} />
       </div>
     </div>
   </section>

--- a/src/app/drink/_components/DrinkBasicInfo.tsx
+++ b/src/app/drink/_components/DrinkBasicInfo.tsx
@@ -1,0 +1,36 @@
+import { Database } from '@/types/supabase';
+
+type Drink = Database['public']['Tables']['drinks']['Row'];
+
+const DrinkBasicInfo = ({ drink }: { drink: Drink }) => (
+  <section className="border-b p-4">
+    <h3 className="text-lg font-bold">기본 정보</h3>
+    <div className="mt-1">
+      <p className="mt-1 text-sm text-gray-500">
+        {drink.ingredients || '재료 정보 없음'}
+      </p>
+      <div className="mt-2 space-y-2 text-sm">
+        <div className="flex justify-between">
+          <p className="font-semibold">주종</p>
+          <p className="text-gray-700">{drink.type || '정보 없음'}</p>
+        </div>
+        <div className="flex justify-between">
+          <p className="font-semibold">도수</p>
+          <p className="text-gray-700">
+            {drink.alcohol_content || '정보 없음'}
+          </p>
+        </div>
+        <div className="flex justify-between">
+          <p className="font-semibold">용량</p>
+          <p className="text-gray-700">{drink.volume || '정보 없음'}</p>
+        </div>
+        <div className="flex justify-between">
+          <p className="font-semibold">제조사</p>
+          <p className="text-gray-700">{drink.manufacturer || '정보 없음'}</p>
+        </div>
+      </div>
+    </div>
+  </section>
+);
+
+export default DrinkBasicInfo;

--- a/src/app/drink/_components/DrinkDescription.tsx
+++ b/src/app/drink/_components/DrinkDescription.tsx
@@ -1,0 +1,21 @@
+// DrinkDescription Component
+const DrinkDescription = ({
+  name,
+  description,
+}: {
+  name: string;
+  description: string | null;
+}) => (
+  <section className="border-b p-4">
+    <div className="flex items-center justify-between">
+      <h2 className="text-xl font-bold">{name}</h2>
+      <div className="flex space-x-4">
+        <button>❤️</button>
+        <button>🔗</button>
+      </div>
+    </div>
+    <p className="mt-2 text-sm text-gray-500">{description || '설명 없음'}</p>
+  </section>
+);
+
+export default DrinkDescription;

--- a/src/app/drink/_components/DrinkDetail.tsx
+++ b/src/app/drink/_components/DrinkDetail.tsx
@@ -1,125 +1,64 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { Database } from '@/types/supabase';
 import { fetchFoodPairings } from '@/utils/foodpairing/action'; // 적절한 경로로 설정하세요
 
+import DrinkBasicInfo from './DrinkBasicInfo';
+import DrinkDescription from './DrinkDescription';
+import DrinkImage from './DrinkImage';
+import DynamicHeader from './DynamicHeader';
 import FoodPairing from './FoodPairing';
+import FoodPairingSkeleton from './FoodPairingSkeleton';
 
 type Drink = Database['public']['Tables']['drinks']['Row'];
-
-type FoodPairing = {
-  id: string;
-  food_name: string;
-  food_image: string | null;
-};
 
 type DrinkDetailProps = {
   drink: Drink;
 };
 
 const DrinkDetail = ({ drink }: DrinkDetailProps) => {
-  const [foodPairings, setFoodPairings] = useState<FoodPairing[] | null>(null); // 타입 정의
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!drink.id) return;
-
-    const loadFoodPairings = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const response = await fetchFoodPairings(drink.id); // 반환 타입: FoodPairing[]
-        setFoodPairings(response || []); // response가 없을 경우 빈 배열 설정
-      } catch (err) {
-        console.error('Error fetching food pairings:', err);
-        setError('음식 페어링 데이터를 불러오는 중 오류가 발생했습니다.');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadFoodPairings();
-  }, [drink.id]);
+  const {
+    data: foodPairings = [],
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['foodPairings', drink.id],
+    queryFn: () => fetchFoodPairings(drink.id),
+    enabled: !!drink.id, // 쿼리 실행 조건 설정
+  });
 
   return (
-    <div className="mx-auto max-w-md">
-      {/* Main Image */}
-      <div className="relative">
-        <button className="absolute left-2 top-2 text-lg">{'<'}</button>
-        <div className="flex h-64 w-full items-center justify-center rounded-lg">
-          {drink.image ? (
-            <img
-              src={drink.image}
-              alt={drink.name}
-              className="h-auto max-h-full w-auto max-w-full rounded-lg object-contain"
-            />
+    <div className="relative">
+      <DynamicHeader
+        name={drink.name}
+        onBackClick={() => console.log('뒤로가기')}
+        onFavoriteClick={() => console.log('좋아요 클릭')}
+        onShareClick={() => console.log('공유하기 클릭')}
+      />
+
+      <div className="mx-auto max-w-md">
+        <DrinkImage image={drink.image} name={drink.name} />
+        <DrinkDescription name={drink.name} description={drink.description} />
+        <DrinkBasicInfo drink={drink} />
+
+        {/* Food Pairings */}
+        <section className="border-b p-4">
+          {isLoading ? (
+            <FoodPairingSkeleton />
+          ) : isError ? (
+            <p className="text-sm text-red-500">
+              {error instanceof Error ? error.message : '오류 발생'}
+            </p>
+          ) : foodPairings.length > 0 ? (
+            <FoodPairing pairings={foodPairings} />
           ) : (
-            <p className="text-lg font-semibold">대표이미지</p>
+            <p className="text-sm text-gray-500">추천 페어링 음식 정보 없음</p>
           )}
-        </div>
+        </section>
       </div>
-
-      {/* 술 이름과 Description */}
-      <section className="border-b p-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-xl font-bold">{drink.name}</h2>
-          <div className="flex space-x-4">
-            <button>❤️</button>
-            <button>🔗</button>
-          </div>
-        </div>
-        <p className="mt-2 text-sm text-gray-500">
-          {drink.description || '설명 없음'}
-        </p>
-      </section>
-
-      {/* Basic Info */}
-      <section className="border-b p-4">
-        <h3 className="text-lg font-bold">기본 정보</h3>
-        <div className="mt-1">
-          <p className="mt-1 text-sm text-gray-500">
-            {drink.ingredients || '재료 정보 없음'}
-          </p>
-          <div className="mt-2 space-y-2 text-sm">
-            <div className="flex justify-between">
-              <p className="font-semibold">주종</p>
-              <p className="text-gray-700">{drink.type || '정보 없음'}</p>
-            </div>
-            <div className="flex justify-between">
-              <p className="font-semibold">도수</p>
-              <p className="text-gray-700">
-                {drink.alcohol_content || '정보 없음'}
-              </p>
-            </div>
-            <div className="flex justify-between">
-              <p className="font-semibold">용량</p>
-              <p className="text-gray-700">{drink.volume || '정보 없음'}</p>
-            </div>
-            <div className="flex justify-between">
-              <p className="font-semibold">제조사</p>
-              <p className="text-gray-700">
-                {drink.manufacturer || '정보 없음'}
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Food Pairings */}
-      <section className="border-b p-4">
-        {loading ? (
-          <p className="text-sm text-gray-500">로딩 중...</p>
-        ) : error ? (
-          <p className="text-sm text-red-500">{error}</p>
-        ) : foodPairings && foodPairings.length > 0 ? (
-          <FoodPairing pairings={foodPairings} />
-        ) : (
-          <p className="text-sm text-gray-500">추천 페어링 음식 정보 없음</p>
-        )}
-      </section>
     </div>
   );
 };

--- a/src/app/drink/_components/DrinkImage.tsx
+++ b/src/app/drink/_components/DrinkImage.tsx
@@ -1,0 +1,24 @@
+const DrinkImage = ({
+  image,
+  name,
+}: {
+  image: string | null;
+  name: string;
+}) => (
+  <div className="relative">
+    <button className="absolute left-2 top-2 text-lg">{'<'}</button>
+    <div className="flex h-64 w-full items-center justify-center rounded-lg">
+      {image ? (
+        <img
+          src={image}
+          alt={name}
+          className="h-auto max-h-full w-auto max-w-full rounded-lg object-contain"
+        />
+      ) : (
+        <p className="text-lg font-semibold">대표이미지</p>
+      )}
+    </div>
+  </div>
+);
+
+export default DrinkImage;

--- a/src/app/drink/_components/DrinkInfoRow.tsx
+++ b/src/app/drink/_components/DrinkInfoRow.tsx
@@ -1,0 +1,13 @@
+type InfoRowProps = {
+  label: string;
+  value: string | null;
+};
+
+const DrinkInfoRow = ({ label, value }: InfoRowProps) => (
+  <div className="flex justify-between">
+    <p className="font-semibold">{label}</p>
+    <p className="text-gray-700">{value || '정보 없음'}</p>
+  </div>
+);
+
+export default DrinkInfoRow;

--- a/src/app/drink/_components/DynamicHeader.tsx
+++ b/src/app/drink/_components/DynamicHeader.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type DynamicHeaderProps = {
+  name: string;
+  onBackClick: () => void;
+  onFavoriteClick: () => void;
+  onShareClick: () => void;
+};
+
+const DynamicHeader = ({
+  name,
+  onBackClick,
+  onFavoriteClick,
+  onShareClick,
+}: DynamicHeaderProps) => {
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrolled(window.scrollY > 200); // 스크롤 200px 이상일 때만 true
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return (
+    <div
+      className={`fixed left-0 top-0 z-50 w-full p-4 transition-all ${
+        scrolled
+          ? 'bg-white text-gray-900 shadow-md' // 스크롤 상태에서 보이게
+          : 'hidden' // 스크롤이 없으면 숨김
+      }`}
+    >
+      <div className="relative flex items-center justify-between">
+        {/* 뒤로가기 버튼 */}
+        <button onClick={onBackClick} className="text-lg">
+          {'<'}
+        </button>
+
+        {/* 술 이름 */}
+        <p className="absolute left-1/2 -translate-x-1/2 transform text-base font-bold">
+          {name}
+        </p>
+
+        {/* 좋아요 및 공유 버튼 */}
+        <div className="flex space-x-4">
+          <button onClick={onFavoriteClick}>❤️</button>
+          <button onClick={onShareClick}>🔗</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DynamicHeader;

--- a/src/app/drink/_components/FoodPairingSkeleton.tsx
+++ b/src/app/drink/_components/FoodPairingSkeleton.tsx
@@ -1,0 +1,27 @@
+const FoodPairingSkeleton = () => {
+  return (
+    <div className="p-4">
+      {/* 제목 자리 표시자 */}
+      <div className="mb-4 animate-pulse">
+        <h3 className="text-lg font-bold">추천 페어링 음식</h3>
+      </div>
+
+      {/* 음식 카드 자리 표시자 */}
+      <div className="grid grid-cols-3 justify-items-center gap-6">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div
+            key={index}
+            className="flex animate-pulse flex-col items-center justify-center space-y-2"
+          >
+            {/* 원형 이미지 자리 표시자 */}
+            <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-full bg-gray-300" />
+            {/* 텍스트 자리 표시자 */}
+            <div className="h-4 w-16 rounded bg-gray-300" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default FoodPairingSkeleton;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from 'next/font/google';
 import ScrollTop from '@/components/common/ScrollTop';
 import Footer from '@/components/layout/Footer';
 import Header from '@/components/layout/Header';
+import Providers from '@/providers/Provider';
 import '@/styles/globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -21,10 +22,12 @@ const RootLayout = ({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <Header />
-        {children}
-        <ScrollTop />
-        <Footer />
+        <Providers>
+          <Header />
+          {children}
+          <ScrollTop />
+          <Footer />
+        </Providers>
       </body>
     </html>
   );

--- a/src/providers/Provider.tsx
+++ b/src/providers/Provider.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React, { useState } from 'react';
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}


### PR DESCRIPTION
## 📌 PR 제목

✨ Feat : 술 이름 가려지면 상단바 생성 및 코드 리팩토링(설명)

---

## ✨ 변경 사항

- [x] 주요 기능 추가/수정
- [x] 코드 개선
- [x] 기타 변경 사항

---

## 🔍 변경 이유

1. 모바일 환경에서 스크롤바 하단으로 이동시에 술 이름이 가려지면 상단바가 생깁니다.
2. 기존에 페어링 음식을 불러오는 부분을 탄스택쿼리로 수정했습니다. (+ 프로바이더 셋팅)
3. DrinkDetail 코드가 좀 지저분해보여서 컴포넌트를 분리했습니다.
4. 페어링 음식 로딩시 FoodPairingSkeleton이 출력됩니다.
5. DrinkBasicInfo 반복 로직 개선했습니다. (대장이 시킴)

---

## ✅ 확인 사항

- [x] 코드는 로컬에서 테스트를 완료했습니다.

---

## 💡 추가 참고 사항

무한스크롤 기능은 실제 리뷰를 작성한 이후에 진행해야될것같습니다.
다음 작업은 공유하기를 진행해볼게요.
JIRA에도 기록해뒀습니다.

---
