### PR TITLE
로그인 후 유저 정보를 가져오지 못하는 오류 해결

### DIFF
--- a/src/hooks/auth/useSignIn.ts
+++ b/src/hooks/auth/useSignIn.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 import { useAuthStore } from '@/store/authStore';
 import { SignInDataType } from '@/types/Auth';
-import { fetchUser, signin } from '@/utils/auth/action';
+import { signin } from '@/utils/auth/action';
 
 type UseSignInProps = {
   handleSuccess: () => void;
@@ -44,9 +44,9 @@ const useSignIn = ({ handleSuccess }: UseSignInProps) => {
 
   const onSubmit = async (values: SignInDataType) => {
     try {
-      await signin(values);
+      const user = await signin(values);
       window.alert('로그인 성공');
-      setUser(await fetchUser());
+      setUser(user);
       handleSuccess();
     } catch (error: any) {
       window.alert(error);

--- a/src/utils/auth/action.ts
+++ b/src/utils/auth/action.ts
@@ -16,7 +16,7 @@ export const signup = async (data: SignUpDataType): Promise<void> => {
     email,
     password,
     options: {
-      data: { nickname, birth },
+      data: { nickname, birth, profile_image: '' },
     },
   });
 
@@ -35,34 +35,27 @@ export const signup = async (data: SignUpDataType): Promise<void> => {
 };
 
 /* 로그인 */
-export const signin = async (data: SignInDataType): Promise<void> => {
+export const signin = async (data: SignInDataType): Promise<UserType> => {
   const supabase = createClient();
 
   const { email, password } = data;
 
-  const { error } = await supabase.auth.signInWithPassword({
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.signInWithPassword({
     email,
     password,
   });
 
   if (error) throw new Error(error.message);
-};
 
-/* 사용자 정보 가져오기 */
-export const fetchUser = async (): Promise<UserType | null> => {
-  console.log(1);
-  const supabase = createClient();
-
-  const { data: authData, error: authError } = await supabase.auth.getUser();
-
-  if (authError || !authData.user) return null;
-  const { data, error } = await supabase
-    .from('users')
-    .select('id, nickname, profile_image, birth')
-    .eq('id', authData.user.id)
-    .single();
-
-  return error ? null : data;
+  return {
+    id: user.id,
+    nickname: user.user_metadata.nickname,
+    birth: user.user_metadata.birth,
+    profile_image: user.user_metadata.profile_image,
+  };
 };
 
 /* 로그아웃 */


### PR DESCRIPTION
## 📌 PR 제목

로그인 후 유저 정보를 가져오지 못하는 오류 해결

---

## ✨ 변경 사항

- [ ] 주요 기능 추가/수정
- [x] 버그 수정
- [ ] 성능 개선
- [ ] 기타 변경 사항

---

## 🔍 변경 이유

- 동일한 코드임에도 불구하고 누구는 되고 누구는 안되는 문제 발생
- fetchUser가 제대로 실행되지 않는 것으로 파악됨
- fetchUser를 호출하는 대신, 로그인 성공 시 반환되는 데이터를 user에 넣어줌

---

## ✅ 확인 사항

- [x] 예시) 코드는 로컬에서 테스트를 완료했습니다.

---

## 💡 추가 참고 사항

- 로그인 후에 유저 정보 제대로 가져오는지 확인해주세요.
- 회원가입 시 profile_image를 추가로 meta_data에 넣어야해서 기존 데이터 다 삭제했으니 회원가입 다시 해주세요.

---
