### PR TITLE
🐛 Bug : 비로그인시 주류 상세페이지 안들어가지는 오류 수정

### DIFF
--- a/src/app/drink/_components/DrinkDescription.tsx
+++ b/src/app/drink/_components/DrinkDescription.tsx
@@ -1,5 +1,7 @@
+'use client';
+
 import LikeButton from '@/components/common/LikeButton';
-import { fetchUser } from '@/utils/auth/action';
+import { useAuthStore } from '@/store/authStore';
 
 import ShareButton from './ShareButton';
 
@@ -10,13 +12,13 @@ type DrinkDescriptionProps = {
   drinkId: string;
 };
 
-const DrinkDescription = async ({
+const DrinkDescription = ({
   name,
   imageUrl,
   description,
   drinkId,
 }: DrinkDescriptionProps) => {
-  const user = await fetchUser();
+  const { user } = useAuthStore();
   return (
     <section className="border-b p-4">
       <div className="flex items-center justify-between">

--- a/src/app/drink/_components/ShareButton.tsx
+++ b/src/app/drink/_components/ShareButton.tsx
@@ -58,7 +58,7 @@ const ShareButton: React.FC<ShareButtonProps> = ({
         onClick={() => setIsOpen(true)}
         className="flex items-center justify-center rounded-full hover:bg-gray-50"
       >
-        <Share size={24} className="text-black-400" />
+        <Share className="text-black-400 ml-2 h-5 w-5 transition-colors sm:h-6 sm:w-6" />
       </button>
       <ShareModal
         isOpen={isOpen}

--- a/src/components/common/LikeButton.tsx
+++ b/src/components/common/LikeButton.tsx
@@ -31,7 +31,7 @@ const LikeButton = ({ drinkId, userId }: LikeButtonProps) => {
   return (
     <button
       onClick={handleLikeButtonClick}
-      className="flex items-center justify-center rounded-full p-2 transition-colors hover:bg-gray-50"
+      className="flex items-center justify-center rounded-full p-2 transition-colors"
       aria-label={data?.liked ? '좋아요 취소' : '좋아요'}
     >
       <HeartIcon

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -414,7 +414,6 @@ export type Database = {
           id: string
           nickname: string
           profile_image: string | null
-          agree_terms: boolean
         }
         Insert: {
           agree_terms: boolean
@@ -422,7 +421,6 @@ export type Database = {
           id: string
           nickname: string
           profile_image?: string | null
-          agree_terms: boolean
         }
         Update: {
           agree_terms?: boolean
@@ -430,7 +428,6 @@ export type Database = {
           id?: string
           nickname?: string
           profile_image?: string | null
-          agree_terms?: boolean
         }
         Relationships: []
       }


### PR DESCRIPTION
## 📌 PR 제목

🐛 Bug : 비로그인시 주류 상세페이지 안들어가지는 오류 수정

---

## ✨ 변경 사항

- [x] 버그 수정
- [x] 기타 변경 사항

---

## 🔍 변경 내용

1. 비로그인시 주류 상세페이지가 안들어가졌습니다.
➡️ 유저객체를 주스탠드에서 가져오는걸로 수정했더니 다시 작동이 잘됩니다.
2. 좋아요 버튼이 반응형으로 구현이 되어있어서 공유하기 버튼도 똑같은 크기로 조절되게 수정했습니다.

---

## ✅ 확인 사항

- [x] 코드는 로컬에서 테스트(DEV 환경)를 완료했습니다.
- [x] 코드는 로컬에서 테스트(BUILD 환경)를 완료했습니다.
- [x] 코드 리뷰를 위해 충분히 설명이 포함되어 있습니다.

---

## 💡 추가 참고 사항

없습니다.

---
