### PR TITLE
🩹 Fix : 리뷰, 마이페이지 수정

### DIFF
--- a/src/app/drink/_components/DrinkInfoRow.tsx
+++ b/src/app/drink/_components/DrinkInfoRow.tsx
@@ -1,13 +1,18 @@
 type InfoRowProps = {
   label: string;
-  value: string | null;
+  value: string | number | null;
 };
 
-const DrinkInfoRow = ({ label, value }: InfoRowProps) => (
-  <div className="flex justify-between">
-    <p className="font-semibold">{label}</p>
-    <p className="text-gray-700">{value || '정보 없음'}</p>
-  </div>
-);
+const DrinkInfoRow = ({ label, value }: InfoRowProps) => {
+  const formattedValue =
+    typeof value === 'number' ? `${value}%` : value || '정보 없음';
+
+  return (
+    <div className="flex justify-between">
+      <p className="font-semibold">{label}</p>
+      <p className="text-gray-700">{formattedValue}</p>
+    </div>
+  );
+};
 
 export default DrinkInfoRow;

--- a/src/app/drink/_components/ReviewInfo.tsx
+++ b/src/app/drink/_components/ReviewInfo.tsx
@@ -4,12 +4,22 @@ type ReviewInfoProps = {
   nickname: string | null;
   createdAt: string | null;
   rating: number;
+  profile_image: string | null;
 };
 
-const ReviewInfo = ({ nickname, createdAt, rating }: ReviewInfoProps) => {
+const ReviewInfo = ({
+  nickname,
+  createdAt,
+  rating,
+  profile_image,
+}: ReviewInfoProps) => {
   return (
     <div className="mb-5 flex items-start space-x-4">
-      <div className="h-12 w-12 rounded-full bg-gray-300"></div>
+      <img
+        src={profile_image || '/default-avatar.png'}
+        alt={`${nickname || '유저'}의 프로필 이미지`}
+        className="h-12 w-12 rounded-full object-cover"
+      />
       <div className="flex-1">
         <div className="flex items-center justify-between">
           <span className="text-sm font-bold text-gray-800">{nickname}</span>

--- a/src/app/drink/_components/ReviewList.tsx
+++ b/src/app/drink/_components/ReviewList.tsx
@@ -45,6 +45,7 @@ const ReviewList = ({ reviews, user, onUpdate, onDelete }: ReviewListProps) => {
             nickname={review.nickname}
             createdAt={review.created_at}
             rating={review.rating}
+            profile_image={review.profile_image}
           />
           <ReviewContent
             editing={editingId === review.id}

--- a/src/app/drink/_components/ReviewLoginPrompt.tsx
+++ b/src/app/drink/_components/ReviewLoginPrompt.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+export type ReviewLoginPromptProps = {
+  onLoginClick: () => void;
+};
+
+const ReviewLoginPrompt = ({ onLoginClick }: ReviewLoginPromptProps) => {
+  return (
+    <div className="mt-4 space-y-6 rounded-lg border p-4">
+      <div className="relative h-32">
+        <textarea
+          id="comment"
+          className="absolute inset-0 h-full w-full resize-none rounded-lg border border-gray-300 bg-gray-100 p-3 text-center text-sm text-gray-500 focus:outline-none"
+          value="리뷰는 로그인을 해야 작성이 가능합니다."
+          readOnly
+        ></textarea>
+      </div>
+      <button
+        onClick={onLoginClick}
+        className="w-full rounded-lg bg-gray-800 py-2 text-sm text-white hover:bg-gray-700"
+      >
+        로그인 하러 가기
+      </button>
+    </div>
+  );
+};
+
+export default ReviewLoginPrompt;

--- a/src/app/drink/_components/ReviewLoginPrompt.tsx
+++ b/src/app/drink/_components/ReviewLoginPrompt.tsx
@@ -7,13 +7,10 @@ export type ReviewLoginPromptProps = {
 const ReviewLoginPrompt = ({ onLoginClick }: ReviewLoginPromptProps) => {
   return (
     <div className="mt-4 space-y-6 rounded-lg border p-4">
-      <div className="relative h-32">
-        <textarea
-          id="comment"
-          className="absolute inset-0 h-full w-full resize-none rounded-lg border border-gray-300 bg-gray-100 p-3 text-center text-sm text-gray-500 focus:outline-none"
-          value="리뷰는 로그인을 해야 작성이 가능합니다."
-          readOnly
-        ></textarea>
+      <div className="relative flex h-32 items-center justify-center rounded-lg border border-gray-300 bg-gray-100">
+        <p className="text-center text-sm text-gray-500">
+          리뷰는 로그인을 해야 작성이 가능합니다.
+        </p>
       </div>
       <button
         onClick={onLoginClick}

--- a/src/app/drink/_components/ReviewSection.tsx
+++ b/src/app/drink/_components/ReviewSection.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+
 import { useReviewActions } from '@/hooks/review/useReviewActions';
 import { useAuthStore } from '@/store/authStore';
 
 import ReviewForm from './ReviewForm';
 import ReviewList from './ReviewList';
+import ReviewLoginPrompt from './ReviewLoginPrompt';
 import ReviewSkeleton from './ReviewSkeleton';
 
 export type ReviewSectionProps = {
@@ -13,6 +16,8 @@ export type ReviewSectionProps = {
 
 const ReviewSection = ({ drinkId }: ReviewSectionProps) => {
   const { user } = useAuthStore();
+  const router = useRouter();
+  
   const {
     reviews,
     isPending,
@@ -23,10 +28,18 @@ const ReviewSection = ({ drinkId }: ReviewSectionProps) => {
     handleReviewDelete,
   } = useReviewActions(drinkId, user);
 
+  const handleLoginClick = () => {
+    router.push('/signin');
+  };
+
   return (
     <section className="p-4">
       <h3 className="text-lg font-bold">리뷰</h3>
-      <ReviewForm onSubmit={handleReviewSubmit} />
+      {user ? (
+        <ReviewForm onSubmit={handleReviewSubmit} />
+      ) : (
+        <ReviewLoginPrompt onLoginClick={handleLoginClick} />
+      )}
       {isPending ? (
         <ReviewSkeleton />
       ) : isError ? (

--- a/src/app/mypage/_components/MyPageAccountOptions.tsx
+++ b/src/app/mypage/_components/MyPageAccountOptions.tsx
@@ -1,13 +1,17 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
+
 import { useAuthStore } from '@/store/authStore';
 import { logout } from '@/utils/auth/action';
 
 const MyPageAccountOptions = () => {
+  const queryClient = useQueryClient();
   const { removeUser } = useAuthStore();
 
   const handleLogout = async () => {
     await logout();
+    queryClient.removeQueries({ queryKey: ['userProfile'] });
     removeUser();
   };
 

--- a/src/hooks/review/useReviewActions.ts
+++ b/src/hooks/review/useReviewActions.ts
@@ -20,7 +20,6 @@ export type Review = {
 export type ReviewSubmitData = {
   rating: number;
   comment: string;
-  profile_image: string | null;
 };
 
 export type User = {
@@ -76,8 +75,6 @@ export const useReviewActions = (drinkId: string, user: User | null) => {
         userId: user.id,
         content: data.comment,
         rating: data.rating,
-        nickname: user.nickname,
-        profileImage: user.profile_image || null,
       });
 
       console.log('리뷰가 성공적으로 등록되었습니다.');

--- a/src/hooks/review/useReviewActions.ts
+++ b/src/hooks/review/useReviewActions.ts
@@ -14,16 +14,19 @@ export type Review = {
   comment: string;
   rating: number;
   created_at: string | null;
+  profile_image: string | null;
 };
 
 export type ReviewSubmitData = {
   rating: number;
   comment: string;
+  profile_image: string | null;
 };
 
 export type User = {
   id: string;
   nickname: string;
+  profile_image: string | null;
 };
 
 export const useReviewActions = (drinkId: string, user: User | null) => {
@@ -74,6 +77,7 @@ export const useReviewActions = (drinkId: string, user: User | null) => {
         content: data.comment,
         rating: data.rating,
         nickname: user.nickname,
+        profileImage: user.profile_image || null,
       });
 
       console.log('리뷰가 성공적으로 등록되었습니다.');

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -31,6 +31,7 @@ export type Review = {
   comment: string;
   rating: number;
   created_at: string | null;
+  profile_image: string | null;
 };
 
 export type ReviewListProps = {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -16,6 +16,7 @@ export type Database = {
           drink_id: string
           id: string
           nickname: string | null
+          profile_image: string | null
           updated_at: string | null
           user_id: string
         }
@@ -25,6 +26,7 @@ export type Database = {
           drink_id: string
           id?: string
           nickname?: string | null
+          profile_image?: string | null
           updated_at?: string | null
           user_id: string
         }
@@ -34,6 +36,7 @@ export type Database = {
           drink_id?: string
           id?: string
           nickname?: string | null
+          profile_image?: string | null
           updated_at?: string | null
           user_id?: string
         }
@@ -57,7 +60,7 @@ export type Database = {
       drinks: {
         Row: {
           acidity: number | null
-          alcohol_content: string | null
+          alcohol_content: number | null
           body: number | null
           carbonation: number | null
           created_at: string | null
@@ -73,7 +76,7 @@ export type Database = {
         }
         Insert: {
           acidity?: number | null
-          alcohol_content?: string | null
+          alcohol_content?: number | null
           body?: number | null
           carbonation?: number | null
           created_at?: string | null
@@ -89,7 +92,7 @@ export type Database = {
         }
         Update: {
           acidity?: number | null
-          alcohol_content?: string | null
+          alcohol_content?: number | null
           body?: number | null
           carbonation?: number | null
           created_at?: string | null

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -15,8 +15,6 @@ export type Database = {
           created_at: string | null
           drink_id: string
           id: string
-          nickname: string | null
-          profile_image: string | null
           updated_at: string | null
           user_id: string
         }
@@ -25,8 +23,6 @@ export type Database = {
           created_at?: string | null
           drink_id: string
           id?: string
-          nickname?: string | null
-          profile_image?: string | null
           updated_at?: string | null
           user_id: string
         }
@@ -35,8 +31,6 @@ export type Database = {
           created_at?: string | null
           drink_id?: string
           id?: string
-          nickname?: string | null
-          profile_image?: string | null
           updated_at?: string | null
           user_id?: string
         }

--- a/src/utils/review/action.ts
+++ b/src/utils/review/action.ts
@@ -13,7 +13,7 @@ export const fetchReviews = async (drinkId: string) => {
   // 댓글 데이터 조회
   const { data: comments, error: commentsError } = await supabase
     .from('comments')
-    .select('id, user_id, nickname, content, created_at')
+    .select('id, user_id, nickname, content, created_at, profile_image')
     .eq('drink_id', drinkId)
     .order('created_at', { ascending: false });
 
@@ -46,6 +46,7 @@ export const fetchReviews = async (drinkId: string) => {
       comment: comment.content,
       rating: matchingRating ? matchingRating.rating : 0,
       created_at: comment.created_at,
+      profile_image: comment.profile_image || null,
     };
   });
 
@@ -59,12 +60,14 @@ export const submitReview = async ({
   content,
   rating,
   nickname,
+  profileImage,
 }: {
   drinkId: string;
   userId: string;
   content: string;
   rating: number;
   nickname: string;
+  profileImage: string;
 }) => {
   if (
     !drinkId ||
@@ -87,6 +90,7 @@ export const submitReview = async ({
         user_id: userId,
         nickname,
         content,
+        profile_image: profileImage,
         created_at: new Date().toISOString(),
       },
     ])

--- a/src/utils/review/action.ts
+++ b/src/utils/review/action.ts
@@ -2,6 +2,17 @@
 
 import { createClient } from '@/utils/supabase/server';
 
+type CommentWithUser = {
+  id: string;
+  user_id: string;
+  content: string;
+  created_at: string;
+  users: {
+    nickname: string | null;
+    profile_image: string | null;
+  } | null;
+};
+
 // 특정 주류에 대한 리뷰 목록 가져오기
 export const fetchReviews = async (drinkId: string) => {
   if (!drinkId) {
@@ -10,12 +21,26 @@ export const fetchReviews = async (drinkId: string) => {
 
   const supabase = createClient();
 
-  // 댓글 데이터 조회
-  const { data: comments, error: commentsError } = await supabase
+  // 댓글과 유저 데이터 조인하여 조회
+  const { data: comments, error: commentsError } = (await supabase
     .from('comments')
-    .select('id, user_id, nickname, content, created_at, profile_image')
+    .select(
+      `
+    id,
+    user_id,
+    content,
+    created_at,
+    users (
+      nickname,
+      profile_image
+    )
+  `,
+    )
     .eq('drink_id', drinkId)
-    .order('created_at', { ascending: false });
+    .order('created_at', { ascending: false })) as {
+    data: CommentWithUser[];
+    error: any;
+  };
 
   if (commentsError) {
     throw new Error(commentsError.message);
@@ -42,11 +67,11 @@ export const fetchReviews = async (drinkId: string) => {
     return {
       id: comment.id,
       user_id: comment.user_id,
-      nickname: comment.nickname,
+      nickname: comment.users?.nickname,
       comment: comment.content,
       rating: matchingRating ? matchingRating.rating : 0,
       created_at: comment.created_at,
-      profile_image: comment.profile_image || null,
+      profile_image: comment.users?.profile_image,
     };
   });
 
@@ -59,23 +84,13 @@ export const submitReview = async ({
   userId,
   content,
   rating,
-  nickname,
-  profileImage,
 }: {
   drinkId: string;
   userId: string;
   content: string;
   rating: number;
-  nickname: string;
-  profileImage: string;
 }) => {
-  if (
-    !drinkId ||
-    !userId ||
-    !content ||
-    typeof rating !== 'number' ||
-    !nickname
-  ) {
+  if (!drinkId || !userId || !content || typeof rating !== 'number') {
     throw new Error('Invalid input data');
   }
 
@@ -88,9 +103,7 @@ export const submitReview = async ({
       {
         drink_id: drinkId,
         user_id: userId,
-        nickname,
         content,
-        profile_image: profileImage,
         created_at: new Date().toISOString(),
       },
     ])


### PR DESCRIPTION
## 📌 PR 제목

🩹 Fix : 리뷰, 마이페이지 수정

---

## ✨ 변경 사항

- [x] 주요 기능 추가/수정
- [x] 버그 수정
- [x] 성능 개선
- [x] 기타 변경 사항

---

## 🔍 변경 내용

1. 작성된 리뷰목록에 프로필 이미지 나오게 수정했습니다.
2. 비로그인시 리뷰작성을 막아놓고 로그인이 유도되게끔 했습니다.
3. 로그아웃시 캐시가 지워지지 않아서 관련로직을 추가했습니다.
4. fetchReviews할때 유저테이블 조인으로 유저 정보를 가져오게끔 수정했습니다.

---

## ✅ 확인 사항

- [x] 코드는 로컬에서 테스트(DEV 환경)를 완료했습니다.
- [x] 코드는 로컬에서 테스트(BUILD 환경)를 완료했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰를 위해 충분히 설명이 포함되어 있습니다.

---

## 💡 추가 참고 사항

- ~~리뷰에 프로필 이미지가 나오게 하기 위하여 갖가지 방법을 시도해보다가 실패하고
결국 comments 테이블을 수정했습니다. pull받으신 이후에 yarn genTypes하셔야됩니다.~~

- fetchReviews할때 댓글과 유저 데이터 조인하여 데이터를 가져옵니다.
이제 유저의 정보도 연동되고 프로필 수정한것도 반영됩니다. (테이블에 권한설정이  추가적으로 있었습니다.꼭 알아두세요!!)
그리고 테이블 또 수정됐으니까 yarn genTypes 꼭 한 번더 하세용..

- 리뷰목록에 프로필 이미지가 잘나오나 테스트 하던중에 아이디1 로그아웃 후, 아이디2를 로그인 했을때
마이페이지에 아이디 2의 정보가 뜨질 않는 버그를 발견했습니다. 새로고침을 해야 뜨더라구요.
이 방법 저 방법 찾아보다가 로그아웃 버튼을 눌렀을때 캐시를 초기화하는 로직을 추가했습니다.

---
