### PR TITLE
카카오맵 Too Many Request 원인 파악

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,10 +36,6 @@ const RootLayout = ({
           src="https://developers.kakao.com/sdk/js/kakao.min.js"
           strategy="lazyOnload"
         />
-        <Script
-          src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY}&libraries=services&autoload=false`}
-          strategy="beforeInteractive"
-        />
       </head>
       <body className="antialiased">
         <Providers>

--- a/src/app/place/_components/KakaoMap.tsx
+++ b/src/app/place/_components/KakaoMap.tsx
@@ -1,3 +1,4 @@
+import Script from 'next/script';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
 
 type PlaceMapProps = {
@@ -13,6 +14,10 @@ const KakaoMap = ({ location_x, location_y }: PlaceMapProps) => {
 
   return (
     <div>
+      <Script
+        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY}&libraries=services&autoload=false`}
+        strategy="beforeInteractive"
+      />
       <Map
         className="h-[200px] w-full bg-gray-200"
         center={{ lat: location_x, lng: location_y }}

--- a/src/components/auth/Button.tsx
+++ b/src/components/auth/Button.tsx
@@ -79,7 +79,7 @@ const Button = ({ category = 'main', label, handleClick }: ButtonProps) => {
       {category.includes('back') && (
         <button
           type="button"
-          className="absolute left-2 top-[2px] flex items-center justify-center"
+          className="absolute left-2 top-[2px] flex items-center justify-center z-20"
           onClick={handleClick}
         >
           <OptimizedImage


### PR DESCRIPTION
## 📌 PR 제목

카카오맵 Too Many Request 원인 파악

---

## ✨ 변경 사항

- [ ] 주요 기능 추가/수정
- [ ] 버그 수정
- [x] 성능 개선
- [x] 기타 변경 사항

---

## 🔍 변경 내용

- 다이닝바 상세 페이지에서 back 버튼이 안보여서 z-index 변경
- 카카오맵 API 불러오는 Script를 전역에서 불러오지 않고 맵 사용 페이지에서 호출

---

## ✅ 확인 사항

- [ ] 코드는 로컬에서 테스트(DEV 환경)를 완료했습니다.
- [ ] 코드는 로컬에서 테스트(BUILD 환경)를 완료했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 코드 리뷰를 위해 충분히 설명이 포함되어 있습니다.

---

## 💡 추가 참고 사항

카카오맵 API를 불러오는 Script를 layout.tsx에서 불러오고 있어서 다이닝바 상세 페이지가 아님에도 불구하고 카카오맵을 호출하고 있어서 이것도 Too Many Request를 발생시키는 하나의 원인이었던 것 같습니다. Kakao Developer에 심사 신청 해놓은거 승인되는데로 추가 테스트 해볼게요.

---
