### PR TITLE
💄 Z-index 값 수정 : searchBar 헤더 침범

### DIFF
--- a/src/app/search/_components/FocusInput.tsx
+++ b/src/app/search/_components/FocusInput.tsx
@@ -34,7 +34,7 @@ const FocusInput: React.FC<FocusInputProps> = ({
       <div
         className={`mx-auto mt-[32px] block w-[100%] max-w-md pb-0 xl:mt-[162px] xl:flex xl:max-w-none xl:items-center xl:justify-center xl:gap-5 ${isFiltered ? '!pb-0' : 'xl:pb-[108px]'}`}
       >
-        <div className={`relative z-50 xl:h-auto`}>
+        <div className={`relative z-30 xl:h-auto`}>
           <SearchBar value={searchValue} onChange={setSearchValue} />
           {isSearchFocus && (
             <RecommendCategory setSearchValue={setSearchValue} />


### PR DESCRIPTION
SearchBar가 Header보다 z축이 높게 잡혀있었음

## 📌 PR 제목

💄 Z-index 값 수정 : searchBar 헤더 침범

---

## ✨ 변경 사항

- [ ] 주요 기능 추가/수정
- [ ] 버그 수정
- [ ] 성능 개선
- [x] 기타 변경 사항

---

## 🔍 변경 내용

SearchBar가 Header보다 z축이 높게 잡혀있었음

---

## ✅ 확인 사항

- [x] 코드는 로컬에서 테스트(DEV 환경)를 완료했습니다.
- [x] 코드는 로컬에서 테스트(BUILD 환경)를 완료했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 코드 리뷰를 위해 충분히 설명이 포함되어 있습니다.

---

## 💡 추가 참고 사항

없습니다!

---
